### PR TITLE
fix(ThreadSafeChannel): prevent double-release race condition in clos…

### DIFF
--- a/tests/test_channel_pool_race_condition.py
+++ b/tests/test_channel_pool_race_condition.py
@@ -2,6 +2,8 @@
 
 import unittest.mock
 
+import pytest
+
 
 def test_channel_close__reentrant_calls__prevented(
     connection,
@@ -41,6 +43,63 @@ def test_channel_close__reentrant_calls__prevented(
     # Channel should be in pool exactly once (not duplicated)
     assert get_kombu_resource_all_objects(pool) == [channel]
     assert get_kombu_resource_free_objects(pool) == [channel]
+
+
+def test_channel_close__reentrant_via_pool_release__prevented(
+    connection,
+    mocker,
+    get_kombu_resource_all_objects,
+    get_kombu_resource_free_objects,
+):
+    """Test that close() guards against true re-entrant calls via pool.release().
+
+    This simulates the original regression scenario where pool.release()
+    (or callbacks it triggers) re-enters channel.close() while a release
+    is already in progress. The _is_releasing flag should prevent a
+    second release and avoid recursion.
+    """
+    pool = connection.default_channel_pool
+
+    channel = pool.acquire()
+    assert get_kombu_resource_all_objects(pool) == [channel]
+    assert get_kombu_resource_free_objects(pool) == []
+
+    original_release = pool.release
+    release_call_count = {"count": 0}
+
+    def release_with_reentrancy(resource):
+        # Count how many times pool.release is actually invoked
+        release_call_count["count"] += 1
+
+        # On the first release call, simulate a re-entrant close()
+        # happening from inside pool.release (or its callbacks).
+        if release_call_count["count"] == 1:
+            # This should be a no-op because _is_releasing is already True
+            channel.close()
+
+        # Delegate to the original implementation
+        return original_release(resource)
+
+    # Monkeypatch pool.release to simulate re-entrant scenario
+    mocker.patch.object(pool, "release", side_effect=release_with_reentrancy)
+
+    # Act: closing the channel should trigger exactly one pool.release call
+    channel.close()
+
+    # Assert: pool.release was only executed once (re-entrant call was blocked)
+    assert release_call_count["count"] == 1
+
+    # Assert: channel is detached
+    assert channel.channel_pool is None
+
+    # Assert: channel returned to pool exactly once (no duplicates)
+    all_after = get_kombu_resource_all_objects(pool)
+    free_after = get_kombu_resource_free_objects(pool)
+
+    assert channel in free_after
+    # Check no duplicates
+    assert free_after.count(channel) == 1
+    assert all_after.count(channel) == 1
 
 
 def test_channel_collect__double_release__prevented(
@@ -125,6 +184,56 @@ def test_channel_close__pool_detachment__atomic(
     # Verify channel was returned to pool successfully
     assert get_kombu_resource_all_objects(pool) == [channel]
     assert get_kombu_resource_free_objects(pool) == [channel]
+
+
+def test_channel_close__pool_release_error__flag_reset(
+    connection,
+    mocker,
+    get_kombu_resource_all_objects,
+    get_kombu_resource_free_objects,
+):
+    """Ensure _is_releasing is reset even if pool.release raises.
+
+    This validates the failure path of the try/finally in Channel.close().
+    If pool.release() raises an exception, _is_releasing must still be
+    reset to False so that subsequent close() calls work correctly.
+    """
+
+    class DummyReleaseError(Exception):
+        """Custom exception raised by the patched pool.release."""
+
+    pool = connection.default_channel_pool
+    channel = pool.acquire()
+
+    # Sanity check initial state
+    assert channel._is_releasing is False
+    assert get_kombu_resource_all_objects(pool) == [channel]
+
+    # Patch pool.release to raise an exception
+    def raising_release(resource):
+        raise DummyReleaseError("boom")
+
+    mocker.patch.object(pool, "release", side_effect=raising_release)
+
+    # First close should hit the failure path in try/finally
+    with pytest.raises(DummyReleaseError):
+        channel.close()
+
+    # _is_releasing must be reset so that later closes are not no-ops
+    assert channel._is_releasing is False
+
+    # Channel should be detached from pool despite the error
+    assert channel.channel_pool is None
+
+    # Restore original release for subsequent close
+    mocker.stopall()
+
+    # Second close should work normally (idempotent)
+    channel.close()
+
+    # Channel should still be detached
+    assert channel.channel_pool is None
+    assert channel._is_releasing is False
 
 
 def test_force_close__collect_called__pool_released(

--- a/tests/test_channel_pool_race_condition.py
+++ b/tests/test_channel_pool_race_condition.py
@@ -1,0 +1,164 @@
+"""Test race condition fix in ThreadSafeChannel.close() and collect()."""
+
+import unittest.mock
+
+
+def test_channel_close__reentrant_calls__prevented(
+    connection,
+    mocker,
+    get_kombu_resource_all_objects,
+    get_kombu_resource_free_objects,
+):
+    """Test that re-entrant close() calls are prevented.
+
+    This test verifies the fix for the race condition where:
+    1. close() calls pool.release(self)
+    2. pool.release() may trigger close_resource() which calls super().close()
+    3. super().close() may trigger events that call close() again
+    4. Without protection, this creates infinite recursion or double-release
+    """
+    pool = connection.default_channel_pool
+
+    with pool.acquire() as channel:
+        assert get_kombu_resource_all_objects(pool) == [channel]
+        assert get_kombu_resource_free_objects(pool) == []
+
+        # Spy on pool.release to track calls
+        release_spy = mocker.spy(pool, "release")
+
+        # Simulate re-entrant close by calling it multiple times
+        channel.close()
+        channel.close()  # Should be no-op due to _is_releasing flag
+        channel.close()  # Should be no-op due to _is_releasing flag
+
+        # pool.release should be called only once due to protection
+        assert release_spy.call_count == 1
+        assert release_spy.call_args_list == [unittest.mock.call(channel)]
+
+        # Channel should be detached from pool after first close()
+        assert channel.channel_pool is None
+
+    # Channel should be in pool exactly once (not duplicated)
+    assert get_kombu_resource_all_objects(pool) == [channel]
+    assert get_kombu_resource_free_objects(pool) == [channel]
+
+
+def test_channel_collect__double_release__prevented(
+    connection,
+    mocker,
+    get_kombu_resource_all_objects,
+    get_kombu_resource_free_objects,
+):
+    """Test that collect() doesn't cause double-release with close().
+
+    This test verifies the fix for:
+    1. close() detaches channel from pool before calling pool.release()
+    2. collect() also detaches before calling super().collect()
+    3. This prevents pool.release() being called twice
+    """
+    pool = connection.default_channel_pool
+
+    channel = pool.acquire()
+    assert get_kombu_resource_all_objects(pool) == [channel]
+    assert get_kombu_resource_free_objects(pool) == []
+
+    # Spy on pool.release to track calls
+    release_spy = mocker.spy(pool, "release")
+
+    # Manually call collect (simulating what super().close() might do)
+    channel.collect()
+
+    # pool.release should be called once from collect()
+    assert release_spy.call_count == 1
+    assert release_spy.call_args_list == [unittest.mock.call(channel)]
+
+    # After collect(), channel is not usable, so it's dropped from pool
+    assert not channel.is_usable()
+    assert get_kombu_resource_all_objects(pool) == []
+    assert get_kombu_resource_free_objects(pool) == []
+
+    # Channel should be detached from pool after collect
+    assert channel.channel_pool is None
+
+    # Subsequent close() should not try to add unusable channel to pool again
+    channel.close()
+
+    # Still only one call to pool.release (no duplicate)
+    assert release_spy.call_count == 1
+
+    # Pool should remain empty (channel not duplicated)
+    assert get_kombu_resource_all_objects(pool) == []
+    assert get_kombu_resource_free_objects(pool) == []
+
+
+def test_channel_close__pool_detachment__atomic(
+    connection,
+    mocker,
+    get_kombu_resource_all_objects,
+    get_kombu_resource_free_objects,
+):
+    """Test that channel is atomically detached from pool during close().
+
+    This ensures that once close() starts, the channel cannot be
+    released to pool again, even from re-entrant calls.
+    """
+    pool = connection.default_channel_pool
+
+    channel = pool.acquire()
+    original_pool = channel.channel_pool
+    assert original_pool is not None
+    assert get_kombu_resource_all_objects(pool) == [channel]
+
+    # Spy on pool.release to track calls
+    release_spy = mocker.spy(pool, "release")
+
+    # Call close which should detach from pool
+    channel.close()
+
+    # pool.release should be called exactly once
+    assert release_spy.call_count == 1
+    assert release_spy.call_args_list == [unittest.mock.call(channel)]
+
+    # Channel should be detached
+    assert channel.channel_pool is None
+
+    # Verify channel was returned to pool successfully
+    assert get_kombu_resource_all_objects(pool) == [channel]
+    assert get_kombu_resource_free_objects(pool) == [channel]
+
+
+def test_force_close__collect_called__pool_released(
+    connection,
+    mocker,
+    get_kombu_resource_all_objects,
+    get_kombu_resource_free_objects,
+):
+    """Test that force_close() closes channel and triggers collect().
+
+    force_close() calls super().close() which triggers collect(),
+    but since channel becomes closed (not usable), it's dropped from pool.
+    """
+    pool = connection.default_channel_pool
+
+    channel = pool.acquire()
+    assert get_kombu_resource_all_objects(pool) == [channel]
+    assert get_kombu_resource_free_objects(pool) == []
+
+    # Spy on pool.release to track calls
+    release_spy = mocker.spy(pool, "release")
+
+    # force_close calls super().close() which calls collect()
+    # Channel becomes closed and is dropped from pool
+    channel.force_close()
+
+    # pool.release should be called once through collect()
+    assert release_spy.call_count == 1
+    assert release_spy.call_args_list == [unittest.mock.call(channel)]
+
+    # Channel is not usable after force_close, so dropped from pool
+    assert not channel.is_usable()
+    assert get_kombu_resource_all_objects(pool) == []
+    assert get_kombu_resource_free_objects(pool) == []
+
+    # Channel should be detached from pool after collect()
+    assert channel.channel_pool is None

--- a/tests/test_drain_guard.py
+++ b/tests/test_drain_guard.py
@@ -42,9 +42,7 @@ SEQUENTIAL_HANDOFF_THREADS = 3  # Number of threads for sequential handoff test
 # ====================
 
 
-def collect_thread_results(
-    threads: list[PropagatingThread], timeout: float = 1.0
-) -> list:
+def collect_thread_results(threads: list[PropagatingThread], timeout: float = 1.0) -> list:
     """Join threads and collect return values.
 
     Args:
@@ -61,9 +59,7 @@ def collect_thread_results(
     for idx, thread in enumerate(threads):
         thread.join(timeout=timeout)
         if thread.is_alive():
-            pytest.fail(
-                f"Test design error: thread {idx} did not complete in {timeout}s"
-            )
+            pytest.fail(f"Test design error: thread {idx} did not complete in {timeout}s")
         results.append(thread.ret)
     return results
 
@@ -106,8 +102,7 @@ def assert_elapsed_time_within(
     upper = expected + tolerance
     ctx = f" ({context})" if context else ""
     assert lower <= elapsed <= upper, (
-        f"Elapsed time {elapsed:.3f}s outside expected range "
-        f"[{lower:.3f}s, {upper:.3f}s]{ctx}"
+        f"Elapsed time {elapsed:.3f}s outside expected range [{lower:.3f}s, {upper:.3f}s]{ctx}"
     )
 
 
@@ -182,9 +177,7 @@ class TestSingleThreadedBehavior:
         assert result is True
         guard.finish_drain()
 
-    def test_finish_drain_without_start_raises_assertion(
-        self, guard: DrainGuard
-    ) -> None:
+    def test_finish_drain_without_start_raises_assertion(self, guard: DrainGuard) -> None:
         """Verify assertion fires when finishing non-existent drain.
 
         Calling finish_drain() without prior start_drain() should raise
@@ -202,13 +195,11 @@ class TestSingleThreadedBehavior:
         """
         elapsed, _ = measure_elapsed_time(guard.wait_drain_finished, timeout=1.0)
 
-        assert (
-            elapsed < IMMEDIATE_RETURN_THRESHOLD
-        ), f"Expected immediate return, took {elapsed:.3f}s"
+        assert elapsed < IMMEDIATE_RETURN_THRESHOLD, (
+            f"Expected immediate return, took {elapsed:.3f}s"
+        )
 
-    def test_wait_self_deadlock_detection_raises_assertion(
-        self, guard: DrainGuard
-    ) -> None:
+    def test_wait_self_deadlock_detection_raises_assertion(self, guard: DrainGuard) -> None:
         """Verify assertion prevents thread from waiting for itself.
 
         When a thread that started drain tries to wait for itself:
@@ -217,9 +208,7 @@ class TestSingleThreadedBehavior:
         """
         guard.start_drain()
 
-        with pytest.raises(
-            AssertionError, match="You can not wait your own; deadlock detected"
-        ):
+        with pytest.raises(AssertionError, match="You can not wait your own; deadlock detected"):
             guard.wait_drain_finished()
 
         # Cleanup
@@ -291,12 +280,12 @@ class TestMultiThreadedRaceConditions:
             true_count = sum(1 for _, r in results if r)
             false_count = sum(1 for _, r in results if not r)
 
-            assert (
-                true_count == 1
-            ), f"Iteration {iteration}: expected exactly 1 winner, got {true_count}"
-            assert (
-                false_count == n_threads - 1
-            ), f"Iteration {iteration}: expected {n_threads - 1} losers, got {false_count}"
+            assert true_count == 1, (
+                f"Iteration {iteration}: expected exactly 1 winner, got {true_count}"
+            )
+            assert false_count == n_threads - 1, (
+                f"Iteration {iteration}: expected {n_threads - 1} losers, got {false_count}"
+            )
 
             # Drain should be inactive after iteration
             assert guard.is_drain_active() is False
@@ -550,9 +539,9 @@ class TestEdgeCasesAndErrors:
         t1.join(timeout=thread_timeout)
 
         # Verify immediate return (polling behavior)
-        assert (
-            elapsed_time[0] < POLL_RETURN_THRESHOLD
-        ), f"Expected immediate return, took {elapsed_time[0]:.3f}s"
+        assert elapsed_time[0] < POLL_RETURN_THRESHOLD, (
+            f"Expected immediate return, took {elapsed_time[0]:.3f}s"
+        )
 
     def test_reentrancy_check_rlock_behavior(self, guard: DrainGuard) -> None:
         """Verify RLock allows reentrancy but assertion prevents double-drain.
@@ -649,8 +638,7 @@ class TestIntegrationPatterns:
                     guard.finish_drain()
 
         threads = [
-            PropagatingThread(target=simulate_drain_events, args=(i,))
-            for i in range(n_threads)
+            PropagatingThread(target=simulate_drain_events, args=(i,)) for i in range(n_threads)
         ]
 
         for t in threads:
@@ -669,9 +657,9 @@ class TestIntegrationPatterns:
         waited_count = sum(1 for _, action in completed if action == "waited")
 
         assert drained_count == 1, f"Expected 1 drainer, got {drained_count}"
-        assert (
-            waited_count == n_threads - 1
-        ), f"Expected {n_threads - 1} waiters, got {waited_count}"
+        assert waited_count == n_threads - 1, (
+            f"Expected {n_threads - 1} waiters, got {waited_count}"
+        )
 
         # Final state should be inactive
         assert guard.is_drain_active() is False


### PR DESCRIPTION
## 🐛 Race Condition: Double-Release in ThreadSafeChannel

  ### Problem

  Race condition discovered in `ThreadSafeChannel.close()` and `collect()` methods causing double-release of channel to pool.

  **Stacktrace example from dramatiq-kombu-broker:**
  amqp/connection.py in _on_close at line 668
  init.py in close at line 235
  amqp/channel.py in close at line 235
  init.py in collect at line 219
  init.py in wait at line 89
  amqp/abstract_channel.py in wait at line 99
  amqp/abstract_channel.py in dispatch_method at line 156
  init.py in drain_events at line 281

  ### Root Cause Analysis

  **Re-entrant calls with circular dependency:**

```
  close()
    └─> pool.release(self)
         └─> [pool internal logic may call close_resource()]
              └─> super().close()
                   └─> send_method()
                        └─> wait()
                             └─> drain_events()
                                  └─> dispatch_method()
                                       └─> _on_close()
                                            └─> collect() ← RE-ENTRANT!
                                                 └─> pool.release(self) ← DUPLICATE RELEASE!
```

  **Consequences:**
  - Channel released to pool twice
  - Pool resource invariants violated
  - Potential channel duplication
  - `ChannelLimitExceeded` errors
  - Resource leaks

  ### Solution

  Applied **Fail-Fast with Atomic Operations** (Principle 2A):

  #### 1. Added re-entrancy protection flag
  ```python
  def __init__(self, *args, **kwargs):
      super().__init__(*args, **kwargs)
      self._is_releasing = False  # Prevents re-entrant calls

  2. Atomic pool detachment in close()

  def close(self, *args, **kwargs):
      # Guard against re-entrant calls
      if self._is_releasing:
          return

      pool = self.channel_pool
      if pool is not None:
          # Detach BEFORE releasing to break circular dependency
          self._channel_pool = None
          self._is_releasing = True
          try:
              pool.release(self)
          finally:
              self._is_releasing = False
      else:
          super().close(*args, **kwargs)

  3. Pool detachment in collect()

  def collect(self):
      # ... cleanup ...

      # Detach BEFORE super().collect() to prevent re-entrant calls
      pool = self.channel_pool
      if pool is not None:
          self._channel_pool = None

      super().collect()

      # Release only if we detached above
      if pool is not None:
          pool.release(self)

  Key mechanism: Detaching channel from pool (_channel_pool = None) before any operations breaks the circular dependency and ensures single release.

  Testing

  Added 4 comprehensive tests in test_channel_pool_race_condition.py:

  1. test_channel_close__reentrant_calls__prevented
    - Verifies multiple close() calls only release once
    - Uses mocker.spy to track exact call count
    - Checks pool state with helpers
  2. test_channel_collect__double_release__prevented
    - Verifies collect() + close() don't duplicate release
    - Ensures unusable channels are dropped
    - Confirms pool invariants maintained
  3. test_channel_close__pool_detachment__atomic
    - Verifies atomic detachment during close
    - Checks channel returned to pool correctly
    - Validates no re-entrant releases possible
  4. test_force_close__collect_called__pool_released
    - Verifies force_close() behavior through collect()
    - Checks closed channels are dropped from pool
    - Confirms proper detachment

## Summary by Sourcery

Prevent double-release race conditions when returning ThreadSafeChannel instances to the pool by adding re-entrancy protection and atomic pool detachment in close() and collect().

Bug Fixes:
- Ensure ThreadSafeChannel.close() and collect() cannot re-entrantly release the same channel to the pool multiple times, eliminating double-release race conditions.

Tests:
- Add regression tests validating that close(), collect(), and force_close() interact with the channel pool without re-entrant or duplicate releases and maintain pool invariants.